### PR TITLE
add logic for smushing multi-line strings onto one line first

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,21 +3,33 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"log"
+	"io"
 	"os"
+	"strings"
 
 	"github.com/prometheus/prometheus/promql/parser"
 )
 
 func main() {
+	var lines []string
+
 	scanner := bufio.NewScanner(os.Stdin)
-	scanner.Scan()
-	err := scanner.Err()
-	if err != nil {
-		log.Fatal(err)
+
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
 	}
 
-	expr, err := parser.ParseExpr(scanner.Text())
+	if err := scanner.Err(); err != nil {
+		if err != io.EOF {
+			fmt.Fprintln(os.Stderr, "Error reading input:", err)
+			return
+		}
+	}
+
+	// Smush multiline strings into one line. The promql parser doesn't handle multiline strings.very well.
+	smushed := strings.Join(lines, " ")
+
+	expr, err := parser.ParseExpr(smushed)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error parsing PromQL query: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
The promql parser doesn't seem to handle multi-line input well. In my testing, it often errored out on syntactically correct input. Smushing it all onto a single line seems to remediate this.