### PR TITLE
Add web UI and server mode for PrettyQL formatter

### DIFF
--- a/format.go
+++ b/format.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+// formatPromQL takes a raw PromQL query string and returns the prettified version.
+func formatPromQL(input string) (string, error) {
+	smushed := strings.Join(strings.Fields(input), " ")
+	expr, err := parser.ParseExpr(smushed)
+	if err != nil {
+		return "", err
+	}
+	return expr.Pretty(0), nil
+}

--- a/main.go
+++ b/main.go
@@ -2,15 +2,77 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
+	"io/fs"
+	"log"
+	"net/http"
 	"os"
 	"strings"
 
-	"github.com/prometheus/prometheus/promql/parser"
+	"prettyql/web"
 )
 
-func main() {
+type formatRequest struct {
+	Query string `json:"query"`
+}
+
+type formatResponse struct {
+	Formatted string `json:"formatted,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+func handleFormat(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req formatRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(formatResponse{Error: "invalid JSON request"})
+		return
+	}
+
+	if strings.TrimSpace(req.Query) == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(formatResponse{Error: "query cannot be empty"})
+		return
+	}
+
+	formatted, err := formatPromQL(req.Query)
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		json.NewEncoder(w).Encode(formatResponse{Error: err.Error()})
+		return
+	}
+
+	json.NewEncoder(w).Encode(formatResponse{Formatted: formatted})
+}
+
+func runServer(port int) {
+	staticFiles, err := fs.Sub(web.StaticFiles, ".")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	http.Handle("/", http.FileServer(http.FS(staticFiles)))
+	http.HandleFunc("/api/format", handleFormat)
+
+	addr := fmt.Sprintf(":%d", port)
+	log.Printf("PrettyQL server starting on http://localhost%s", addr)
+	if err := http.ListenAndServe(addr, nil); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func runCLI() {
 	var lines []string
 
 	scanner := bufio.NewScanner(os.Stdin)
@@ -26,14 +88,24 @@ func main() {
 		}
 	}
 
-	// Smush multiline strings into one line. The promql parser doesn't handle multiline strings.very well.
-	smushed := strings.Join(lines, " ")
-
-	expr, err := parser.ParseExpr(smushed)
+	input := strings.Join(lines, " ")
+	result, err := formatPromQL(input)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error parsing PromQL query: %v\n", err)
 		os.Exit(1)
 	}
 
-	fmt.Println(expr.Pretty(0))
+	fmt.Println(result)
+}
+
+func main() {
+	serve := flag.Bool("serve", false, "Start web server instead of reading from stdin")
+	port := flag.Int("port", 8080, "Port to listen on (used with --serve)")
+	flag.Parse()
+
+	if *serve {
+		runServer(*port)
+	} else {
+		runCLI()
+	}
 }

--- a/web/embed.go
+++ b/web/embed.go
@@ -1,0 +1,6 @@
+package web
+
+import "embed"
+
+//go:embed index.html
+var StaticFiles embed.FS

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,741 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PrettyQL - PromQL Formatter</title>
+<style>
+  :root {
+    --bg: #1a1b26;
+    --bg-surface: #24283b;
+    --bg-input: #1a1b26;
+    --border: #3b4261;
+    --text: #c0caf5;
+    --text-muted: #565f89;
+    --accent: #7aa2f7;
+    --accent-hover: #89b4fa;
+    --error: #f7768e;
+    --success: #9ece6a;
+    --keyword: #bb9af7;
+    --string: #9ece6a;
+    --label: #e0af68;
+    --number: #ff9e64;
+    --func: #7dcfff;
+    --bracket: #89ddff;
+  }
+
+  .light {
+    --bg: #f5f5f5;
+    --bg-surface: #ffffff;
+    --bg-input: #ffffff;
+    --border: #d0d0d0;
+    --text: #333333;
+    --text-muted: #888888;
+    --accent: #2563eb;
+    --accent-hover: #1d4ed8;
+    --error: #dc2626;
+    --success: #16a34a;
+    --keyword: #7c3aed;
+    --string: #16a34a;
+    --label: #d97706;
+    --number: #ea580c;
+    --func: #0891b2;
+    --bracket: #0284c7;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  header {
+    padding: 1.25rem 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .logo {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+  }
+
+  .logo h1 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--accent);
+  }
+
+  .logo span {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+  }
+
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .icon-btn {
+    background: none;
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    cursor: pointer;
+    padding: 0.4rem 0.6rem;
+    border-radius: 6px;
+    font-size: 0.85rem;
+    transition: all 0.15s;
+  }
+
+  .icon-btn:hover {
+    color: var(--text);
+    border-color: var(--text-muted);
+  }
+
+  main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    padding: 1.5rem 2rem;
+    gap: 1rem;
+    max-width: 1400px;
+    width: 100%;
+    margin: 0 auto;
+  }
+
+  .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .btn {
+    padding: 0.5rem 1.25rem;
+    border-radius: 6px;
+    border: none;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 500;
+    transition: all 0.15s;
+  }
+
+  .btn-primary {
+    background: var(--accent);
+    color: #fff;
+  }
+
+  .btn-primary:hover { background: var(--accent-hover); }
+
+  .btn-secondary {
+    background: var(--bg-surface);
+    color: var(--text);
+    border: 1px solid var(--border);
+  }
+
+  .btn-secondary:hover { border-color: var(--text-muted); }
+
+  .examples-dropdown {
+    position: relative;
+  }
+
+  .examples-menu {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    margin-top: 0.25rem;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.25rem;
+    z-index: 100;
+    min-width: 340px;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+  }
+
+  .examples-menu.open { display: block; }
+
+  .examples-menu button {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 0.5rem 0.75rem;
+    background: none;
+    border: none;
+    color: var(--text);
+    cursor: pointer;
+    border-radius: 6px;
+    font-size: 0.85rem;
+    font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, monospace;
+  }
+
+  .examples-menu button:hover { background: var(--bg); }
+
+  .shortcut-hint {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    margin-left: auto;
+  }
+
+  .panels {
+    flex: 1;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    min-height: 0;
+  }
+
+  .panel {
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    overflow: hidden;
+    min-height: 300px;
+  }
+
+  .panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.6rem 1rem;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .panel-actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .panel-actions button {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 0.8rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 4px;
+    transition: all 0.15s;
+  }
+
+  .panel-actions button:hover { color: var(--text); background: var(--bg); }
+  .panel-actions button.copied { color: var(--success); }
+
+  textarea {
+    flex: 1;
+    width: 100%;
+    padding: 1rem;
+    background: var(--bg-input);
+    color: var(--text);
+    border: none;
+    resize: none;
+    font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, monospace;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    outline: none;
+  }
+
+  textarea::placeholder { color: var(--text-muted); }
+
+  .output-area {
+    flex: 1;
+    padding: 1rem;
+    overflow: auto;
+    font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, monospace;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    white-space: pre;
+  }
+
+  .output-area .placeholder-text {
+    color: var(--text-muted);
+    font-style: italic;
+    white-space: normal;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  }
+
+  .error-text {
+    color: var(--error);
+    white-space: pre-wrap;
+    font-size: 0.85rem;
+  }
+
+  /* Syntax highlighting */
+  .hl-keyword { color: var(--keyword); font-weight: 600; }
+  .hl-func { color: var(--func); }
+  .hl-string { color: var(--string); }
+  .hl-label-key { color: var(--label); }
+  .hl-number { color: var(--number); }
+  .hl-bracket { color: var(--bracket); }
+  .hl-operator { color: var(--keyword); font-weight: 600; }
+
+  /* Grafana settings popover */
+  .settings-popover {
+    display: none;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.5rem;
+    z-index: 200;
+    width: 420px;
+    box-shadow: 0 16px 48px rgba(0,0,0,0.4);
+  }
+
+  .settings-popover.open { display: block; }
+
+  .settings-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.5);
+    z-index: 199;
+  }
+
+  .settings-overlay.open { display: block; }
+
+  .settings-popover h3 {
+    font-size: 1rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .settings-popover label {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    display: block;
+    margin-bottom: 0.35rem;
+  }
+
+  .settings-popover input[type="text"] {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    background: var(--bg-input);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-size: 0.9rem;
+    outline: none;
+    margin-bottom: 1rem;
+  }
+
+  .settings-popover input[type="text"]:focus { border-color: var(--accent); }
+
+  .settings-popover .btn-row {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+
+  /* Toast notification */
+  .toast {
+    position: fixed;
+    bottom: 2rem;
+    right: 2rem;
+    background: var(--bg-surface);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.75rem 1.25rem;
+    font-size: 0.85rem;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+    transform: translateY(100px);
+    opacity: 0;
+    transition: all 0.3s ease;
+    z-index: 300;
+  }
+
+  .toast.show {
+    transform: translateY(0);
+    opacity: 1;
+  }
+
+  @media (max-width: 768px) {
+    header { padding: 1rem; }
+    main { padding: 1rem; }
+    .panels { grid-template-columns: 1fr; }
+    .shortcut-hint { display: none; }
+    .settings-popover { width: calc(100% - 2rem); }
+  }
+</style>
+</head>
+<body>
+  <header>
+    <div class="logo">
+      <h1>PrettyQL</h1>
+      <span>PromQL Formatter</span>
+    </div>
+    <div class="header-actions">
+      <button class="icon-btn" id="settingsBtn" title="Grafana Settings">Settings</button>
+      <button class="icon-btn" id="themeToggle" title="Toggle theme">Dark</button>
+    </div>
+  </header>
+
+  <main>
+    <div class="toolbar">
+      <button class="btn btn-primary" id="formatBtn">Format</button>
+      <button class="btn btn-secondary" id="minifyBtn">Minify</button>
+      <div class="examples-dropdown">
+        <button class="btn btn-secondary" id="examplesBtn">Examples</button>
+        <div class="examples-menu" id="examplesMenu">
+          <button data-example="sum by (status) (rate(http_requests_total{job=&quot;apiserver&quot;}[5m]))">sum by (status) (rate(http_requests_total...))</button>
+          <button data-example="histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=&quot;apiserver&quot;}[5m])))">histogram_quantile(0.95, sum by (le) ...)</button>
+          <button data-example="label_replace(instance:node_memory_utilisation:ratio{cluster=&quot;mycluster&quot;}, &quot;node&quot;, &quot;$1&quot;, &quot;instance&quot;, &quot;(.+):metrics&quot;) * on(node) group_left(customer) sum by(node) (label_replace(kube_pod_info{cluster=&quot;mycluster&quot;,pod=~&quot;.+mypod.+&quot;},&quot;customer&quot;, &quot;$1&quot;, &quot;namespace&quot;, &quot;(.+)&quot;))">label_replace(...) * on(node) group_left(...)</button>
+          <button data-example="max by (namespace) (sum by (namespace, pod) (rate(container_cpu_usage_seconds_total{namespace!=&quot;&quot;,pod!=&quot;&quot;}[5m])) / on(namespace, pod) group_left() kube_pod_container_resource_limits{resource=&quot;cpu&quot;})">max by (ns) (sum/limits cpu ratio)</button>
+        </div>
+      </div>
+      <button class="btn btn-secondary" id="shareBtn">Share Link</button>
+      <button class="btn btn-secondary" id="grafanaBtn">Open in Grafana</button>
+      <span class="shortcut-hint">Ctrl+Enter to format</span>
+    </div>
+
+    <div class="panels">
+      <div class="panel">
+        <div class="panel-header">
+          <span>Input</span>
+          <div class="panel-actions">
+            <button id="clearBtn">Clear</button>
+          </div>
+        </div>
+        <textarea id="input" placeholder="Paste your ugly PromQL query here..." spellcheck="false"></textarea>
+      </div>
+      <div class="panel">
+        <div class="panel-header">
+          <span>Output</span>
+          <div class="panel-actions">
+            <button id="copyBtn">Copy</button>
+          </div>
+        </div>
+        <div class="output-area" id="output">
+          <span class="placeholder-text">Formatted query will appear here</span>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <div class="settings-overlay" id="settingsOverlay"></div>
+  <div class="settings-popover" id="settingsPopover">
+    <h3>Grafana Settings</h3>
+    <label for="grafanaUrl">Grafana Base URL</label>
+    <input type="text" id="grafanaUrl" placeholder="https://grafana.example.com">
+    <label for="grafanaDatasource">Datasource name (optional)</label>
+    <input type="text" id="grafanaDatasource" placeholder="Prometheus">
+    <div class="btn-row">
+      <button class="btn btn-secondary" id="settingsCancel">Cancel</button>
+      <button class="btn btn-primary" id="settingsSave">Save</button>
+    </div>
+  </div>
+
+  <div class="toast" id="toast"></div>
+
+<script>
+(function() {
+  // DOM elements
+  const input = document.getElementById('input');
+  const output = document.getElementById('output');
+  const formatBtn = document.getElementById('formatBtn');
+  const minifyBtn = document.getElementById('minifyBtn');
+  const copyBtn = document.getElementById('copyBtn');
+  const clearBtn = document.getElementById('clearBtn');
+  const shareBtn = document.getElementById('shareBtn');
+  const grafanaBtn = document.getElementById('grafanaBtn');
+  const themeToggle = document.getElementById('themeToggle');
+  const examplesBtn = document.getElementById('examplesBtn');
+  const examplesMenu = document.getElementById('examplesMenu');
+  const settingsBtn = document.getElementById('settingsBtn');
+  const settingsPopover = document.getElementById('settingsPopover');
+  const settingsOverlay = document.getElementById('settingsOverlay');
+  const settingsCancel = document.getElementById('settingsCancel');
+  const settingsSave = document.getElementById('settingsSave');
+  const grafanaUrlInput = document.getElementById('grafanaUrl');
+  const grafanaDatasourceInput = document.getElementById('grafanaDatasource');
+  const toast = document.getElementById('toast');
+
+  let lastFormattedRaw = '';
+
+  // Theme
+  function setTheme(theme) {
+    if (theme === 'light') {
+      document.body.classList.add('light');
+      themeToggle.textContent = 'Light';
+    } else {
+      document.body.classList.remove('light');
+      themeToggle.textContent = 'Dark';
+    }
+    localStorage.setItem('prettyql-theme', theme);
+  }
+
+  const savedTheme = localStorage.getItem('prettyql-theme') || 'dark';
+  setTheme(savedTheme);
+
+  themeToggle.addEventListener('click', function() {
+    const current = document.body.classList.contains('light') ? 'light' : 'dark';
+    setTheme(current === 'dark' ? 'light' : 'dark');
+  });
+
+  // Toast
+  function showToast(msg, duration) {
+    duration = duration || 2000;
+    toast.textContent = msg;
+    toast.classList.add('show');
+    setTimeout(function() { toast.classList.remove('show'); }, duration);
+  }
+
+  // Syntax highlighting
+  function highlightPromQL(text) {
+    var escaped = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+    // Strings
+    escaped = escaped.replace(/"(?:[^"\\]|\\.)*"/g, '<span class="hl-string">$&</span>');
+
+    // Label keys inside {} — match word before = or != or =~ or !~
+    escaped = escaped.replace(/(\{|,)\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*(=~|!=|!~|=)/g,
+      '$1<span class="hl-label-key">$2</span>$3');
+
+    // Numbers and durations
+    escaped = escaped.replace(/\b(\d+\.?\d*)(ms|s|m|h|d|w|y)?\b/g, function(match, num, unit) {
+      if (unit) return '<span class="hl-number">' + match + '</span>';
+      // Only highlight standalone numbers, not part of identifiers
+      return '<span class="hl-number">' + match + '</span>';
+    });
+
+    // Aggregation keywords
+    var keywords = ['by', 'without', 'on', 'ignoring', 'group_left', 'group_right', 'bool', 'offset'];
+    keywords.forEach(function(kw) {
+      var re = new RegExp('\\b(' + kw + ')\\b', 'g');
+      escaped = escaped.replace(re, '<span class="hl-keyword">$1</span>');
+    });
+
+    // Aggregation operators
+    var aggOps = ['sum', 'avg', 'min', 'max', 'count', 'count_values', 'stddev', 'stdvar',
+                  'topk', 'bottomk', 'quantile', 'group'];
+    aggOps.forEach(function(op) {
+      var re = new RegExp('\\b(' + op + ')\\b', 'g');
+      escaped = escaped.replace(re, '<span class="hl-keyword">$1</span>');
+    });
+
+    // Functions
+    var funcs = ['rate', 'irate', 'increase', 'delta', 'idelta', 'histogram_quantile',
+                 'label_replace', 'label_join', 'vector', 'scalar', 'time', 'timestamp',
+                 'absent', 'absent_over_time', 'ceil', 'floor', 'round', 'clamp',
+                 'clamp_min', 'clamp_max', 'changes', 'resets', 'deriv', 'predict_linear',
+                 'holt_winters', 'exp', 'ln', 'log2', 'log10', 'sqrt', 'abs',
+                 'sort', 'sort_desc', 'day_of_month', 'day_of_week', 'day_of_year',
+                 'days_in_month', 'hour', 'minute', 'month', 'year',
+                 'avg_over_time', 'min_over_time', 'max_over_time', 'sum_over_time',
+                 'count_over_time', 'quantile_over_time', 'stddev_over_time',
+                 'stdvar_over_time', 'last_over_time', 'present_over_time', 'sgn',
+                 'deg', 'rad', 'pi', 'acos', 'acosh', 'asin', 'asinh', 'atan', 'atanh',
+                 'cos', 'cosh', 'sin', 'sinh', 'tan', 'tanh'];
+    funcs.forEach(function(fn) {
+      var re = new RegExp('\\b(' + fn + ')\\b', 'g');
+      escaped = escaped.replace(re, '<span class="hl-func">$1</span>');
+    });
+
+    // Binary operators
+    escaped = escaped.replace(/\b(and|or|unless)\b/g, '<span class="hl-operator">$1</span>');
+
+    return escaped;
+  }
+
+  // Format query
+  async function formatQuery() {
+    var query = input.value.trim();
+    if (!query) {
+      output.innerHTML = '<span class="placeholder-text">Formatted query will appear here</span>';
+      lastFormattedRaw = '';
+      return;
+    }
+
+    formatBtn.disabled = true;
+    formatBtn.textContent = 'Formatting...';
+
+    try {
+      var resp = await fetch('/api/format', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: query })
+      });
+
+      var data = await resp.json();
+
+      if (data.error) {
+        output.innerHTML = '<span class="error-text">' +
+          data.error.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') +
+          '</span>';
+        lastFormattedRaw = '';
+      } else {
+        lastFormattedRaw = data.formatted;
+        output.innerHTML = highlightPromQL(data.formatted);
+      }
+    } catch (err) {
+      output.innerHTML = '<span class="error-text">Failed to connect to server: ' +
+        err.message.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') +
+        '</span>';
+      lastFormattedRaw = '';
+    } finally {
+      formatBtn.disabled = false;
+      formatBtn.textContent = 'Format';
+    }
+  }
+
+  // Event listeners
+  formatBtn.addEventListener('click', formatQuery);
+
+  input.addEventListener('keydown', function(e) {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+      e.preventDefault();
+      formatQuery();
+    }
+  });
+
+  clearBtn.addEventListener('click', function() {
+    input.value = '';
+    output.innerHTML = '<span class="placeholder-text">Formatted query will appear here</span>';
+    lastFormattedRaw = '';
+  });
+
+  // Copy
+  copyBtn.addEventListener('click', function() {
+    if (!lastFormattedRaw) return;
+    navigator.clipboard.writeText(lastFormattedRaw).then(function() {
+      copyBtn.textContent = 'Copied!';
+      copyBtn.classList.add('copied');
+      setTimeout(function() {
+        copyBtn.textContent = 'Copy';
+        copyBtn.classList.remove('copied');
+      }, 1500);
+    });
+  });
+
+  // Minify
+  minifyBtn.addEventListener('click', function() {
+    if (!lastFormattedRaw) return;
+    var minified = lastFormattedRaw.replace(/\n\s*/g, ' ').replace(/\s+/g, ' ').trim();
+    input.value = minified;
+    showToast('Minified query placed in input');
+  });
+
+  // Share link
+  shareBtn.addEventListener('click', function() {
+    var query = input.value.trim();
+    if (!query) {
+      showToast('Enter a query first');
+      return;
+    }
+    var encoded = btoa(unescape(encodeURIComponent(query)));
+    var url = window.location.origin + window.location.pathname + '#q=' + encoded;
+    navigator.clipboard.writeText(url).then(function() {
+      showToast('Share link copied to clipboard!');
+    });
+  });
+
+  // Load from share link
+  function loadFromHash() {
+    var hash = window.location.hash;
+    if (hash && hash.startsWith('#q=')) {
+      try {
+        var decoded = decodeURIComponent(escape(atob(hash.substring(3))));
+        input.value = decoded;
+        formatQuery();
+      } catch (e) {
+        // ignore invalid hash
+      }
+    }
+  }
+  loadFromHash();
+  window.addEventListener('hashchange', loadFromHash);
+
+  // Examples dropdown
+  examplesBtn.addEventListener('click', function(e) {
+    e.stopPropagation();
+    examplesMenu.classList.toggle('open');
+  });
+
+  document.addEventListener('click', function() {
+    examplesMenu.classList.remove('open');
+  });
+
+  examplesMenu.querySelectorAll('button[data-example]').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      input.value = btn.getAttribute('data-example');
+      examplesMenu.classList.remove('open');
+      formatQuery();
+    });
+  });
+
+  // Grafana settings
+  function loadSettings() {
+    grafanaUrlInput.value = localStorage.getItem('prettyql-grafana-url') || '';
+    grafanaDatasourceInput.value = localStorage.getItem('prettyql-grafana-ds') || '';
+  }
+
+  settingsBtn.addEventListener('click', function() {
+    loadSettings();
+    settingsPopover.classList.add('open');
+    settingsOverlay.classList.add('open');
+  });
+
+  function closeSettings() {
+    settingsPopover.classList.remove('open');
+    settingsOverlay.classList.remove('open');
+  }
+
+  settingsCancel.addEventListener('click', closeSettings);
+  settingsOverlay.addEventListener('click', closeSettings);
+
+  settingsSave.addEventListener('click', function() {
+    localStorage.setItem('prettyql-grafana-url', grafanaUrlInput.value.replace(/\/+$/, ''));
+    localStorage.setItem('prettyql-grafana-ds', grafanaDatasourceInput.value);
+    closeSettings();
+    showToast('Settings saved');
+  });
+
+  // Open in Grafana
+  grafanaBtn.addEventListener('click', function() {
+    var baseUrl = localStorage.getItem('prettyql-grafana-url');
+    if (!baseUrl) {
+      loadSettings();
+      settingsPopover.classList.add('open');
+      settingsOverlay.classList.add('open');
+      showToast('Set your Grafana URL first');
+      return;
+    }
+
+    var query = lastFormattedRaw || input.value.trim();
+    if (!query) {
+      showToast('Enter a query first');
+      return;
+    }
+
+    var ds = localStorage.getItem('prettyql-grafana-ds') || 'Prometheus';
+    var left = JSON.stringify({
+      queries: [{ refId: 'A', expr: query, range: true, datasource: { type: 'prometheus', uid: ds } }],
+      range: { from: 'now-1h', to: 'now' }
+    });
+
+    var url = baseUrl + '/explore?orgId=1&left=' + encodeURIComponent(left);
+    window.open(url, '_blank');
+  });
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Transform PrettyQL from a CLI-only tool into a full-featured web application with both server and CLI modes. This adds a modern, interactive web interface while maintaining backward compatibility with the existing command-line interface.

## Key Changes
- **Web UI** (`web/index.html`): Created a comprehensive single-page application featuring:
  - Dual-panel layout with input and syntax-highlighted output
  - Dark/light theme toggle with localStorage persistence
  - Format and minify operations
  - Example queries dropdown
  - Share link generation with base64 encoding
  - Grafana integration for opening queries directly in Grafana
  - Toast notifications and responsive design
  - Syntax highlighting for PromQL with color-coded keywords, functions, strings, and operators

- **Server Mode** (`main.go`): Added HTTP server functionality:
  - New `-serve` flag to start web server instead of reading from stdin
  - `-port` flag to configure listening port (default 8080)
  - `/api/format` POST endpoint that accepts JSON requests and returns formatted queries
  - Embedded static file serving for the web UI

- **Format Extraction** (`format.go`): Refactored formatting logic into a reusable `formatPromQL()` function to support both CLI and API usage

- **Static File Embedding** (`web/embed.go`): Used Go's `embed` package to bundle the HTML UI with the binary for easy distribution

## Implementation Details
- The web UI communicates with the backend via `/api/format` API endpoint
- Share links use base64 encoding to preserve query state in URL fragments
- Grafana integration constructs explore URLs with the formatted query
- Settings (Grafana URL, datasource) are persisted in browser localStorage
- Maintains full backward compatibility: running without `-serve` flag uses the original CLI behavior

https://claude.ai/code/session_019Kp8ALJdkMjrtewNzKbZrs