### PR TITLE
Add WebAssembly support for static site deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+prettyql

--- a/build-wasm.sh
+++ b/build-wasm.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+DIST_DIR="dist"
+
+echo "Building WASM binary..."
+mkdir -p "$DIST_DIR"
+GOOS=js GOARCH=wasm go build -o "$DIST_DIR/prettyql.wasm" ./wasm/
+
+echo "Copying wasm_exec.js from Go installation..."
+cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" "$DIST_DIR/wasm_exec.js"
+
+echo "Copying frontend..."
+cp web/index.html "$DIST_DIR/index.html"
+
+# Get sizes for reporting
+wasm_size=$(du -h "$DIST_DIR/prettyql.wasm" | cut -f1)
+echo ""
+echo "Build complete! Static site files in $DIST_DIR/:"
+ls -lh "$DIST_DIR/"
+echo ""
+echo "To test locally:"
+echo "  cd $DIST_DIR && python3 -m http.server 8080"
+echo ""
+echo "To deploy as a static site, upload the contents of $DIST_DIR/ to your host."

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -1,0 +1,39 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"syscall/js"
+
+	"github.com/prometheus/prometheus/promql/parser"
+	"strings"
+)
+
+func formatPromQL(this js.Value, args []js.Value) interface{} {
+	if len(args) == 0 {
+		return map[string]interface{}{
+			"error": "no query provided",
+		}
+	}
+
+	input := args[0].String()
+	smushed := strings.Join(strings.Fields(input), " ")
+
+	expr, err := parser.ParseExpr(smushed)
+	if err != nil {
+		return map[string]interface{}{
+			"error": err.Error(),
+		}
+	}
+
+	return map[string]interface{}{
+		"formatted": expr.Pretty(0),
+	}
+}
+
+func main() {
+	js.Global().Set("formatPromQL", js.FuncOf(formatPromQL))
+
+	// Block forever so the Go runtime stays alive
+	select {}
+}

--- a/web/index.html
+++ b/web/index.html
@@ -458,7 +458,7 @@
 
   <div class="toast" id="toast"></div>
 
-<script src="wasm_exec.js"></script>
+<script src="wasm_exec.js" onerror="console.log('wasm_exec.js not found, WASM mode unavailable')"></script>
 <script>
 (function() {
   // DOM elements
@@ -487,19 +487,22 @@
 
   // WASM initialization
   async function initWasm() {
-    if (typeof Go === 'undefined') return;
+    if (typeof Go === 'undefined') {
+      console.log('wasm_exec.js not loaded, using API mode');
+      return;
+    }
     try {
       var go = new Go();
-      var result = await WebAssembly.instantiateStreaming(
-        fetch('prettyql.wasm'),
-        go.importObject
-      );
+      var resp = await fetch('prettyql.wasm');
+      if (!resp.ok) throw new Error('prettyql.wasm not found (HTTP ' + resp.status + ')');
+      var result = await WebAssembly.instantiateStreaming(resp, go.importObject);
       go.run(result.instance);
       wasmReady = true;
       document.getElementById('modeIndicator').textContent = 'WASM';
       document.getElementById('modeIndicator').title = 'Running locally in your browser via WebAssembly';
     } catch (e) {
       console.log('WASM not available, falling back to API mode:', e.message);
+      document.getElementById('modeIndicator').title = 'WASM failed to load: ' + e.message + '. Using server API.';
     }
   }
 
@@ -631,8 +634,10 @@
         output.innerHTML = highlightPromQL(data.formatted);
       }
     } catch (err) {
+      var hint = wasmReady ? '' : '\n\nHint: WASM did not load. If running as a static site, make sure prettyql.wasm and wasm_exec.js are in the same directory as index.html (run build-wasm.sh first). If running via the Go server (--serve), this is expected — the server handles formatting.';
       output.innerHTML = '<span class="error-text">Failed to format query: ' +
         err.message.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') +
+        hint.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') +
         '</span>';
       lastFormattedRaw = '';
     } finally {

--- a/web/index.html
+++ b/web/index.html
@@ -368,6 +368,17 @@
     opacity: 1;
   }
 
+  .mode-badge {
+    font-size: 0.7rem;
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    font-weight: 600;
+    letter-spacing: 0.05em;
+  }
+
   @media (max-width: 768px) {
     header { padding: 1rem; }
     main { padding: 1rem; }
@@ -384,6 +395,7 @@
       <span>PromQL Formatter</span>
     </div>
     <div class="header-actions">
+      <span class="mode-badge" id="modeIndicator" title="Formatting via server API">API</span>
       <button class="icon-btn" id="settingsBtn" title="Grafana Settings">Settings</button>
       <button class="icon-btn" id="themeToggle" title="Toggle theme">Dark</button>
     </div>
@@ -446,6 +458,7 @@
 
   <div class="toast" id="toast"></div>
 
+<script src="wasm_exec.js"></script>
 <script>
 (function() {
   // DOM elements
@@ -470,6 +483,30 @@
   const toast = document.getElementById('toast');
 
   let lastFormattedRaw = '';
+  let wasmReady = false;
+
+  // WASM initialization
+  async function initWasm() {
+    if (typeof Go === 'undefined') return;
+    try {
+      var go = new Go();
+      var result = await WebAssembly.instantiateStreaming(
+        fetch('prettyql.wasm'),
+        go.importObject
+      );
+      go.run(result.instance);
+      wasmReady = true;
+      document.getElementById('modeIndicator').textContent = 'WASM';
+      document.getElementById('modeIndicator').title = 'Running locally in your browser via WebAssembly';
+    } catch (e) {
+      console.log('WASM not available, falling back to API mode:', e.message);
+    }
+  }
+
+  function formatViaWasm(query) {
+    var result = formatPromQL(query);
+    return result;
+  }
 
   // Theme
   function setTheme(theme) {
@@ -569,13 +606,20 @@
     formatBtn.textContent = 'Formatting...';
 
     try {
-      var resp = await fetch('/api/format', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ query: query })
-      });
+      var data;
 
-      var data = await resp.json();
+      if (wasmReady) {
+        // Use WASM — synchronous, no network needed
+        data = formatViaWasm(query);
+      } else {
+        // Fall back to server API
+        var resp = await fetch('/api/format', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ query: query })
+        });
+        data = await resp.json();
+      }
 
       if (data.error) {
         output.innerHTML = '<span class="error-text">' +
@@ -587,7 +631,7 @@
         output.innerHTML = highlightPromQL(data.formatted);
       }
     } catch (err) {
-      output.innerHTML = '<span class="error-text">Failed to connect to server: ' +
+      output.innerHTML = '<span class="error-text">Failed to format query: ' +
         err.message.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') +
         '</span>';
       lastFormattedRaw = '';
@@ -735,6 +779,9 @@
     var url = baseUrl + '/explore?orgId=1&left=' + encodeURIComponent(left);
     window.open(url, '_blank');
   });
+
+  // Initialize WASM if wasm_exec.js was loaded
+  initWasm();
 })();
 </script>
 </body>


### PR DESCRIPTION
Compile the PromQL formatter to WASM so the frontend can run entirely in the browser with no server backend. This enables free static hosting on GitHub Pages, Cloudflare Pages, Netlify, etc.

- Add wasm/main.go: Go entrypoint that exposes formatPromQL() to JS
- Add build-wasm.sh: builds WASM binary and assembles dist/ directory
- Update index.html: auto-detect WASM availability, fall back to API
- Add .gitignore for dist/ build output

The server mode (--serve) continues to work as before. The frontend gracefully degrades: if WASM is available it runs client-side, otherwise it calls the /api/format endpoint.

https://claude.ai/code/session_019Kp8ALJdkMjrtewNzKbZrs